### PR TITLE
fix viewport scaling matrix

### DIFF
--- a/docs/tinyrenderer/camera.md
+++ b/docs/tinyrenderer/camera.md
@@ -262,7 +262,7 @@ std::tuple<int,int,int> project(vec3 v) { // First of all, (x,y) is an orthogona
 In fact, it is a by-hand computation of the following matrix multiplication:
 
 $$
-\begin{bmatrix}\frac{\text{width}}{2}&0&0&\frac{\text{height}}{2} \\ 0&\frac{\text{height}}{2}&0&\frac{\text{height}}{2}\\ 0&0&\frac{255}{2}&\frac{255}{2}\\ 0 &0 &0&1\end{bmatrix}
+\begin{bmatrix}\frac{\text{width}}{2}&0&0&\frac{\text{width}}{2} \\ 0&\frac{\text{height}}{2}&0&\frac{\text{height}}{2}\\ 0&0&\frac{255}{2}&\frac{255}{2}\\ 0 &0 &0&1\end{bmatrix}
 \begin{bmatrix}v_x \\ v_y \\ v_z \\ 1\end{bmatrix}
 $$
 


### PR DESCRIPTION
The current viewport scaling matrix uses $\frac{width}{2}$ and $\frac{height}{2}$ in the first row, which would create an unintended offset.

I assume for valid homogeneous coordinates, $A_{14}$ was intended to be $\frac{width}{2}$ instead.

---

Thank you very much for the original and updated guide! I learned a lot with the original and I'm now using the updated version and my existing C++ implementation to learn Rust.